### PR TITLE
Change remember me tokens to many:many table

### DIFF
--- a/database_updates.php
+++ b/database_updates.php
@@ -1607,10 +1607,17 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.0.6'");
     }
 
-    // if (CURRENT_DATABASE_VERSION == '1.0.6') {
-    //     // Insert queries here required to update to DB version 1.0.7
+    if (CURRENT_DATABASE_VERSION == '1.0.6') {
+        // Insert queries here required to update to DB version 1.0.7
+        mysqli_query($mysqli, "CREATE TABLE `remember_tokens` (`remember_token_id` int(11) NOT NULL AUTO_INCREMENT,`remember_token_token` varchar(255) NOT NULL,`remember_token_user_id` int(11) NOT NULL,`remember_token_created_at` datetime NOT NULL DEFAULT current_timestamp()");
+        // Then, update the database to the next sequential version
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.0.7'");
+    }
+
+    // if (CURRENT_DATABASE_VERSION == '1.0.7') {
+    //     // Insert queries here required to update to DB version 1.0.8
     //     // Then, update the database to the next sequential version
-    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.0.7'");
+    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.0.8'");
     // }
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,5 +5,5 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "1.0.6");
+DEFINE("LATEST_DATABASE_VERSION", "1.0.7");
 

--- a/db.sql
+++ b/db.sql
@@ -1042,6 +1042,22 @@ CREATE TABLE `recurring_expenses` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table remember_tokens
+--
+
+DROP TABLE IF EXISTS `remember_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `remember_tokens` (
+  `remember_token_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `remember_token_user_id` int(10) unsigned NOT NULL,
+  `remember_token_token` varchar(100) NOT NULL,
+  `remember_token_created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
+--
 -- Table structure for table `revenues`
 --
 

--- a/login.php
+++ b/login.php
@@ -111,14 +111,21 @@ if (isset($_POST['login'])) {
         $user_email = sanitizeInput($row['user_email']);
         $token = sanitizeInput($row['user_token']);
         $force_mfa = intval($row['user_config_force_mfa']);
-        $remember_token = $row['user_config_remember_me_token'];
         if($force_mfa == 1 && $token == NULL) {
             $config_start_page = "user_security.php";
         }
 
+        // Get remember tokens less than 2 days old
+        $remember_tokens = mysqli_query($mysqli, "SELECT remember_token_token FROM remember_tokens WHERE remember_token_user_id = $user_id AND remember_token_created_at > (NOW() - INTERVAL 2 DAY)");
+
         $bypass_2fa = false;
-        if (isset($_COOKIE['rememberme']) && $_COOKIE['rememberme'] == $remember_token) {
-            $bypass_2fa = true;
+        if (isset($_COOKIE['rememberme'])) {
+            while ($row = mysqli_fetch_assoc($remember_tokens)) {
+                if (hash_equals($row['remember_token_token'], $_COOKIE['rememberme'])) {
+                    $bypass_2fa = true;
+                    break;
+                }
+            }
         } elseif (empty($token) || TokenAuth6238::verify($token, $current_code)) {
             $bypass_2fa = true;
         }
@@ -127,7 +134,7 @@ if (isset($_POST['login'])) {
             if (isset($_POST['remember_me'])) {
                 $newRememberToken = bin2hex(random_bytes(64));
                 setcookie('rememberme', $newRememberToken, time() + 86400*2, "/", null, true, true);
-                $updateTokenQuery = "UPDATE user_settings SET user_config_remember_me_token = '$newRememberToken' WHERE user_id = $user_id";
+                $updateTokenQuery = "INSERT INTO remember_tokens (remember_token_user_id, remember_token_token) VALUES ($user_id, '$newRememberToken')";
                 mysqli_query($mysqli, $updateTokenQuery);
             }
 


### PR DESCRIPTION
This pull request adds a new table called `remember_tokens` to store remember me tokens for users. It also updates the code to use this new table for remember me functionality. This many:many relationship allows for more than one device to be remembered at a time.